### PR TITLE
Feature/v2 Make ProgressBar accept breakpoints

### DIFF
--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import Exercise from "../exercise/Exercise";
+import BreakPointFiller from "./components/BreakPointFiller/BreakPointFiller";
 import Button from "./components/Button/Button";
 import ProgressBar from "./components/ProgressBar/ProgressBar";
 import "./Solution.scss";
@@ -22,10 +23,15 @@ export default ProgressBarExercise;
 
 const Solution = () => {
   const [loading, setLoading] = useState(false);
+  const [breakpoints, setBreakpoints] = useState([50, 75]);
 
   return (
     <div className="solution">
-      <ProgressBar loading={loading} />
+      <ProgressBar
+        loading={loading}
+        breakpoints={breakpoints}
+        expectedSeconds={10}
+      />
       <div className="solution__buttons">
         <Button onClick={() => setLoading(true)}>
           {loading ? "Loading..." : "Start Request"}
@@ -34,6 +40,11 @@ const Solution = () => {
           Finish Request
         </Button>
       </div>
+      <BreakPointFiller
+        breakpoints={breakpoints}
+        setBreakpoints={setBreakpoints}
+        loading={loading}
+      />
     </div>
   );
 };

--- a/src/progress_bar_exercise/components/BreakPointFiller/BreakPointFiller.js
+++ b/src/progress_bar_exercise/components/BreakPointFiller/BreakPointFiller.js
@@ -1,0 +1,87 @@
+import React, { useRef } from "react";
+import Button from "../Button/Button";
+
+import "./BreakPointFiller.scss";
+
+const BreakPointFiller = ({ breakpoints, setBreakpoints, loading }) => {
+  const newValueRef = useRef(null);
+  const handleEditBreakpoint = (index, value) => {
+    setBreakpoints((oldBreakpoints) => {
+      const newBPs = [...oldBreakpoints];
+      newBPs[index] = value;
+      return newBPs;
+    });
+  };
+
+  const handleAddBreakpoint = () => {
+    setBreakpoints((oldBreakpoints) => {
+      return [...oldBreakpoints, Number(newValueRef.current.value)];
+    });
+  };
+
+  const handleRemoveBreakpoint = (index) => {
+    setBreakpoints((oldBreakpoints) => {
+      const newBPs = [...oldBreakpoints];
+      newBPs.splice(index, 1);
+      return newBPs;
+    });
+  };
+
+  return (
+    <div className="breakpoint-filler">
+      <div className="breakpoint-filler__summary">
+        <p>
+          Breakpoints:{" "}
+          <span>
+            {breakpoints.length > 0
+              ? JSON.stringify(breakpoints)
+              : "No breakpoints"}
+          </span>
+        </p>
+      </div>
+      {!loading && (
+        <div className="breakpoint-filler__defaults">
+          <Button size="s" onClick={() => setBreakpoints([])}>
+            No breakpoints
+          </Button>
+          <Button size="s" onClick={() => setBreakpoints([50, 75])}>
+            Default breakpoints
+          </Button>
+        </div>
+      )}
+      {!loading && (
+        <div>
+          {breakpoints.map((breakpoint, index) => {
+            return (
+              <div key={index} className="breakpoint-filler__row">
+                <input
+                  type="number"
+                  max={90}
+                  value={breakpoint}
+                  onChange={(e) =>
+                    handleEditBreakpoint(index, Number(e.target.value))
+                  }
+                />
+                <Button
+                  size="s"
+                  variant="danger"
+                  onClick={() => handleRemoveBreakpoint(index)}
+                >
+                  -
+                </Button>
+              </div>
+            );
+          })}
+          <div className="breakpoint-filler__add-container">
+            <input ref={newValueRef} type="number" max={90} />
+            <Button onClick={handleAddBreakpoint} size="s">
+              +
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BreakPointFiller;

--- a/src/progress_bar_exercise/components/BreakPointFiller/BreakPointFiller.scss
+++ b/src/progress_bar_exercise/components/BreakPointFiller/BreakPointFiller.scss
@@ -1,0 +1,39 @@
+@import "../../../shared_styles/resets.scss";
+@import "../../../shared_styles/colors.scss";
+@import "../../../shared_styles/typography.scss";
+@import "../../../shared_styles/general.scss";
+
+.breakpoint-filler {
+  margin-top: 10px;
+  max-width: 380px;
+
+  &__summary {
+    margin-bottom: 5px;
+  }
+
+  &__defaults {
+    display: flex;
+    justify-content: space-between;
+    .btn:first-of-type {
+      margin-right: 10px;
+    }
+  }
+
+  &__row {
+    margin: 5px 0px;
+  }
+
+  &__add-container {
+    border-top: 1px solid $gray-light;
+    margin-top: 8px;
+    padding-top: 8px;
+  }
+
+  input {
+    width: 40px;
+    margin-right: 10px;
+    border-radius: 2px;
+    border-width: 1px;
+    border-color: $gray-light;
+  }
+}

--- a/src/progress_bar_exercise/components/Button/Button.js
+++ b/src/progress_bar_exercise/components/Button/Button.js
@@ -1,9 +1,13 @@
 import React from "react";
 import "./Button.scss";
 
-const Button = ({ children, variant = "primary", ...props }) => {
+
+// Types should be handled by ts or prop-types
+// variant: 'primary' | 'danger'
+// size: 'm' | 's'
+const Button = ({ children, variant = "primary", size="m", ...props }) => {
   return (
-    <button {...props} className={`btn ${variant}`}>
+    <button {...props} className={`btn ${variant} size-${size}`}>
       {children}
     </button>
   );

--- a/src/progress_bar_exercise/components/Button/Button.scss
+++ b/src/progress_bar_exercise/components/Button/Button.scss
@@ -6,6 +6,9 @@
 $vertical-padding: 18px;
 $horizontal-padding: 33px;
 
+$small-vertical-padding: 5px;
+$small-horizontal-padding: 15px;
+
 button.btn {
   border-width: 1px;
   border-style: solid;
@@ -30,5 +33,18 @@ button.btn {
   &:active {
     border-width: 3px;
     padding: $vertical-padding - 2 $horizontal-padding - 2;
+  }
+
+  &.size-s {
+    padding: $small-vertical-padding $small-horizontal-padding;
+
+    &:hover {
+      border-width: 2px;
+      padding: $small-vertical-padding - 1 $small-horizontal-padding - 1;
+    }
+    &:active {
+      border-width: 3px;
+      padding: $small-vertical-padding - 2 $small-horizontal-padding - 2;
+    }
   }
 }

--- a/src/progress_bar_exercise/components/ProgressBar/ProgressBar.js
+++ b/src/progress_bar_exercise/components/ProgressBar/ProgressBar.js
@@ -1,24 +1,32 @@
 import React, { useEffect, useMemo } from "react";
 import "./ProgressBar.scss";
 import { DEFAULT_SECONDS, useProgressBarState } from "./useProgressBarState";
+const DEFAULT_BREAKPOINTS = [];
 
 // Normally we would be using prop-types or typescript to type-check our props
-const ProgressBar = ({ loading, expectedSeconds = DEFAULT_SECONDS }) => {
+const ProgressBar = ({
+  loading,
+  expectedSeconds = DEFAULT_SECONDS,
+  breakpoints = DEFAULT_BREAKPOINTS,
+}) => {
   const {
     hasStarted,
     transitionDuration,
-    stopMilliseconds,
     animatedProgress,
-    addNormalAnimation,
+    addInitialAnimation,
     handleDone,
-  } = useProgressBarState(expectedSeconds);
+    handleUpdateBreakpoints,
+  } = useProgressBarState(expectedSeconds, breakpoints);
+
+  useEffect(() => {
+    handleUpdateBreakpoints(breakpoints);
+  }, [handleUpdateBreakpoints, breakpoints]);
 
   useEffect(() => {
     if (loading) {
-      addNormalAnimation(stopMilliseconds);
+      addInitialAnimation();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading]);
+  }, [addInitialAnimation, loading]);
 
   useEffect(() => {
     if (!loading && hasStarted) {

--- a/src/progress_bar_exercise/components/ProgressBar/ProgressBar.scss
+++ b/src/progress_bar_exercise/components/ProgressBar/ProgressBar.scss
@@ -3,17 +3,6 @@
 @import "../../../shared_styles/typography.scss";
 @import "../../../shared_styles/general.scss";
 
-@keyframes fadeOut {
-  from {
-    visibility: visible;
-    opacity: 1;
-  }
-  to {
-    visibility: hidden;
-    opacity: 0;
-  }
-}
-
 .progress-bar {
   height: 8px;
   width: 100%;
@@ -37,7 +26,7 @@
 
     &.normal-step {
       transition-property: width;
-      transition-timing-function: linear;
+      transition-timing-function: ease-in-out;
     }
 
     &.done {

--- a/src/progress_bar_exercise/components/ProgressBar/ProgressBar.test.js
+++ b/src/progress_bar_exercise/components/ProgressBar/ProgressBar.test.js
@@ -3,40 +3,85 @@ import { render, screen, waitFor } from "@testing-library/react";
 import ProgressBar from "./ProgressBar";
 
 describe("ProgressBar", () => {
-  it("Renders hidden when loading false", () => {
-    render(<ProgressBar loading={false} />);
-    const progressBar = screen.getByTestId("progress-bar");
-    expect(progressBar.className).toBe("progress-bar hidden");
+  describe("No breakPoints", () => {
+    it("Renders hidden when loading false", () => {
+      render(<ProgressBar loading={false} />);
+      const progressBar = screen.getByTestId("progress-bar");
+      expect(progressBar.className).toBe("progress-bar hidden");
+    });
+
+    it("Animates when loading true", async () => {
+      const expectedSeconds = 15;
+      render(<ProgressBar loading expectedSeconds={expectedSeconds} />);
+
+      const progressBar = screen.getByTestId("progress-bar");
+      const progressBarInner = screen.getByTestId("progress-bar-inner");
+
+      expect(progressBar.className).toBe("progress-bar visible");
+      expect(progressBarInner.className).toBe("progress-bar__inner ");
+      expect(progressBarInner.style.width).toBe("0%");
+
+      await waitFor(() => expect(progressBarInner).toHaveClass("normal-step"));
+      expect(progressBarInner.style.width).toBe("90%");
+    });
+
+    it("Animates when loading true and when back to false", async () => {
+      const expectedSeconds = 15;
+      const { rerender } = render(
+        <ProgressBar loading expectedSeconds={expectedSeconds} />
+      );
+
+      const progressBarInner = screen.getByTestId("progress-bar-inner");
+
+      await waitFor(() => expect(progressBarInner).toHaveClass("normal-step"));
+      expect(progressBarInner.style.width).toBe("90%");
+
+      rerender(
+        <ProgressBar loading={false} expectedSeconds={expectedSeconds} />
+      );
+      expect(progressBarInner).toHaveClass("done");
+      expect(progressBarInner.style.width).toBe("100%");
+    });
   });
 
-  it("Animates when loading true", async () => {
-    const expectedSeconds = 15;
-    render(<ProgressBar loading expectedSeconds={expectedSeconds} />);
+  describe("Breakpoints", () => {
+    it("Works with breakpoints", async () => {
+      render(
+        <ProgressBar loading expectedSeconds={3} breakpoints={[20, 50]} />
+      );
 
-    const progressBar = screen.getByTestId("progress-bar");
-    const progressBarInner = screen.getByTestId("progress-bar-inner");
+      const progressBar = screen.getByTestId("progress-bar");
+      const progressBarInner = screen.getByTestId("progress-bar-inner");
 
-    expect(progressBar.className).toBe("progress-bar visible");
-    expect(progressBarInner.className).toBe("progress-bar__inner ");
-    expect(progressBarInner.style.width).toBe("0%");
+      expect(progressBar.className).toBe("progress-bar visible");
+      expect(progressBarInner.className).toBe("progress-bar__inner ");
+      expect(progressBarInner.style.width).toBe("0%");
 
-    await waitFor(() => expect(progressBarInner).toHaveClass("normal-step"));
-    expect(progressBarInner.style.width).toBe("90%");
-  });
+      await waitFor(() => expect(progressBarInner.style.width).toBe("20%"));
+      await waitFor(() => expect(progressBarInner.style.width).toBe("50%"));
+      await waitFor(() => expect(progressBarInner.style.width).toBe("90%"));
+    });
 
-  it("Animates when loading true and when back to false", async () => {
-    const expectedSeconds = 15;
-    const { rerender } = render(
-      <ProgressBar loading expectedSeconds={expectedSeconds} />
-    );
+    it("Works with breakpoints not sorted and higher than 100", async () => {
+      render(
+        <ProgressBar
+          loading
+          expectedSeconds={3}
+          breakpoints={[80, 50, 20, 100]}
+        />
+      );
 
-    const progressBarInner = screen.getByTestId("progress-bar-inner");
+      const progressBar = screen.getByTestId("progress-bar");
+      const progressBarInner = screen.getByTestId("progress-bar-inner");
 
-    await waitFor(() => expect(progressBarInner).toHaveClass("normal-step"));
-    expect(progressBarInner.style.width).toBe("90%");
+      expect(progressBar.className).toBe("progress-bar visible");
+      expect(progressBarInner.className).toBe("progress-bar__inner ");
+      expect(progressBarInner.style.width).toBe("0%");
 
-    rerender(<ProgressBar loading={false} expectedSeconds={expectedSeconds} />);
-    expect(progressBarInner).toHaveClass("done");
-    expect(progressBarInner.style.width).toBe("100%");
+      await waitFor(() => expect(progressBarInner.style.width).toBe("20%"));
+      await waitFor(() => expect(progressBarInner.style.width).toBe("50%"));
+      await waitFor(() => expect(progressBarInner.style.width).toBe("80%"));
+      expect(progressBarInner.style.width).not.toBe("100%");
+    });
   });
 });

--- a/src/progress_bar_exercise/components/ProgressBar/useProgressBarState.js
+++ b/src/progress_bar_exercise/components/ProgressBar/useProgressBarState.js
@@ -1,101 +1,148 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useCallback, useEffect, useReducer, useRef } from "react";
 
 export const DEFAULT_SECONDS = 15;
 export const ONE_SECOND = 1000;
-const PERCENTAGE_STOP = 90;
+const MAX_PERCENTAGE = 90;
 
 const ACTIONS = {
-  reset: "RESET",
-  addNormalAnimation: "ADD_NORMAL_ANIMATION",
-  setTime: "SET_TIME",
+  addAnimation: "ADD_ANIMATION",
   done: "DONE",
+  reset: "RESET",
+  updateBreakpoints: "UPDATE_BREAKPOINTS",
 };
 
 const initialState = {
-  passedMilliseconds: 0,
   transitionDuration: 0,
-  realProgress: 0,
   animatedProgress: 0,
   hasStarted: false,
+  breakpointIndex: 0, // We use this to keep iterating until the last breakpoint
 };
 
-function init(initialState) {
-  const expectedMilliseconds = initialState.expectedSeconds * ONE_SECOND;
-  return {
-    ...initialState,
+function init({ breakpoints, ...initState }) {
+  // Here we are sorting them so we don't go backwards, filtering values lower than our max (90) and adding the MAX at the end
+  let newBreakpoints = breakpoints
+    .sort((a, b) => a - b)
+    .filter((breakpoint) => breakpoint < MAX_PERCENTAGE);
+  newBreakpoints.push(MAX_PERCENTAGE);
+
+  const expectedMilliseconds = initState.expectedSeconds * ONE_SECOND;
+  const currentBreakPoint = getBreakPoint(
+    newBreakpoints,
+    initState.breakpointIndex
+  );
+
+  const nextTimeout = getDurationByBP(
     expectedMilliseconds,
-    stopMilliseconds: expectedMilliseconds * (PERCENTAGE_STOP / 100.0),
+    undefined,
+    currentBreakPoint
+  );
+
+  return {
+    ...initState,
+    breakpoints: newBreakpoints,
+    expectedMilliseconds,
+    nextTimeout,
+    stopMilliseconds: expectedMilliseconds * (MAX_PERCENTAGE / 100.0),
   };
 }
 
-const getProgress = (passedTime, totalTime) => {
-  return Math.round((passedTime / totalTime) * 100);
+const getBreakPoint = (breakpoints, index) => {
+  return breakpoints?.[index];
+};
+
+const getBreakpointMilliseconds = (totalMilliseconds, breakpoint) => {
+  return breakpoint ? totalMilliseconds * (breakpoint / 100.0) : undefined;
+};
+
+const getDurationByBP = (totalMilliseconds, fromBP, toBP) => {
+  const fromMs = getBreakpointMilliseconds(totalMilliseconds, fromBP) || 0;
+  const toMs = getBreakpointMilliseconds(totalMilliseconds, toBP);
+  return toMs ? toMs - fromMs : toMs;
 };
 
 function reducer(state, action) {
+  const breakpointByIndex = (index) => getBreakPoint(state.breakpoints, index);
+
   switch (action.type) {
-    case ACTIONS.addNormalAnimation:
+    case ACTIONS.addAnimation:
+      const currentBreakPoint = breakpointByIndex(state.breakpointIndex);
+      const nextBreakPoint = breakpointByIndex(state.breakpointIndex + 1);
+      const prevBreakPoint = breakpointByIndex(state.breakpointIndex - 1);
+
+      const transitionDuration = getDurationByBP(
+        state.expectedMilliseconds,
+        prevBreakPoint,
+        currentBreakPoint
+      );
+      const nextTimeout = getDurationByBP(
+        state.expectedMilliseconds,
+        currentBreakPoint,
+        nextBreakPoint
+      );
       return {
         ...state,
+        animatedProgress: currentBreakPoint,
+        breakpointIndex: state.breakpointIndex + 1,
         hasStarted: true,
-        transitionDuration: action.payload,
-        animatedProgress: getProgress(
-          action.payload,
-          state.expectedMilliseconds
-        ),
-      };
-    case ACTIONS.setTime:
-      return {
-        ...state,
-        passedMilliseconds: action.payload,
-        realProgress: getProgress(action.payload, state.expectedMilliseconds),
+        nextTimeout,
+        transitionDuration: transitionDuration,
       };
     case ACTIONS.done:
       return {
         ...state,
         transitionDuration: ONE_SECOND,
         animatedProgress: 100,
-        realProgress: 0,
       };
     case ACTIONS.reset:
-      return { ...state, ...initialState };
+      return init({
+        ...initialState,
+        expectedSeconds: state.expectedSeconds,
+        breakpoints: state.breakpoints,
+      });
+    case ACTIONS.updateBreakpoints:
+      return init({
+        ...initialState,
+        expectedSeconds: state.expectedSeconds,
+        breakpoints: action.payload,
+      });
     default:
       return state;
   }
 }
 
-export const useProgressBarState = (expectedSeconds) => {
+export const useProgressBarState = (expectedSeconds, breakpoints) => {
   const resetTimeRef = useRef(null);
   const timePassedRef = useRef(null);
   const [state, dispatch] = useReducer(
     reducer,
-    { ...initialState, expectedSeconds },
+    { ...initialState, expectedSeconds, breakpoints },
     init
   );
+  // As we're using timeouts, we need a way to consistently get the most updated value, so we're using a ref for this
+  const nextTimeoutRef = useRef(state.nextTimeout);
+  useEffect(() => {
+    nextTimeoutRef.current = state.nextTimeout;
+  }, [state.nextTimeout]);
 
-  const isFinishingDoneAnimation = useMemo(
-    () => state.hasStarted && state.realProgress === 0,
-    [state.hasStarted, state.realProgress]
-  );
+  // Keep adding animations until there's no nextTimeout
+  const addAnimation = useCallback(() => {
+    dispatch({ type: ACTIONS.addAnimation });
 
-  // Add animation for 15 seconds, then set a timer to when that time has passed to actually set that time has passed
-  const addNormalAnimation = useCallback(
-    (animationTime) => {
-      if (isFinishingDoneAnimation) {
-        // When we're finishing an animation
-        clearTimeout(resetTimeRef.current);
-        dispatch({ type: ACTIONS.reset });
-      }
-      setTimeout(() => {
-        dispatch({ type: ACTIONS.addNormalAnimation, payload: animationTime });
-      }, 0);
-
+    if (nextTimeoutRef.current) {
       timePassedRef.current = setTimeout(() => {
-        dispatch({ type: ACTIONS.setTime, payload: animationTime });
-      }, animationTime);
-    },
-    [isFinishingDoneAnimation]
-  );
+        addAnimation();
+      }, nextTimeoutRef.current);
+    }
+  }, []);
+
+  const addInitialAnimation = useCallback(() => {
+    clearTimeout(resetTimeRef.current);
+    clearTimeout(timePassedRef.current);
+    dispatch({ type: ACTIONS.reset });
+    setTimeout(() => {
+      addAnimation();
+    }, 0);
+  }, [addAnimation]);
 
   const handleDone = useCallback(() => {
     clearTimeout(timePassedRef.current);
@@ -106,6 +153,10 @@ export const useProgressBarState = (expectedSeconds) => {
     }, 4 * ONE_SECOND);
   }, []);
 
+  const handleUpdateBreakpoints = useCallback((newBreakpoints) => {
+    dispatch({ type: ACTIONS.updateBreakpoints, payload: newBreakpoints });
+  }, []);
+
   // Clear timer when unmounted
   useEffect(() => {
     return () => {
@@ -114,5 +165,11 @@ export const useProgressBarState = (expectedSeconds) => {
     };
   }, []);
 
-  return { ...state, addNormalAnimation, handleDone, dispatch };
+  return {
+    ...state,
+    addInitialAnimation,
+    dispatch,
+    handleDone,
+    handleUpdateBreakpoints,
+  };
 };


### PR DESCRIPTION
## Description

This request solves V2 of the [Progress Bar Exercise](https://github.com/SpiffInc/spiff_react_exercises/issues/1).

## Where should the reviewer start?
- `src/progress_bar_exercise/ProgressBarExercise.js`
- `src/progress_bar_exercise/components/ProgressBar/useProgressBarState.js`
- `src/progress_bar_exercise/components/ProgressBar/ProgressBar.js`

## Changes:
- Added support for smaller buttons
- Added a `BreakPointFiller` component to be able to choose the breakpoints with a user friendly UI. This component shouldn't go to production, it's only there to make testing of the breakpoints easier. The usage of this component is as follows:

https://user-images.githubusercontent.com/10641301/147418927-8a004b9e-c0e7-4272-8352-9d0f0c622a3c.mov

- Removing some not needed code
- Modified the `ProgressBar` to work with breakpoints, while keeping the previous behavior intact.
The interface to add them is:
```jsx
  const breakpoints = [50, 75];

      <ProgressBar
        loading={loading}
        breakpoints={breakpoints}
        expectedSeconds={10}
      />
```

## Recordings

Here we're first showing the behavior of it working with 2 breakpoints, then adding another one and still working.

Both cases work with the 90% rule too

https://user-images.githubusercontent.com/10641301/147419128-a17dc715-291b-4566-b110-d477af23e4ac.mov


## Assumptions
- Same assumptions as in [previous PR](https://github.com/robesonck/spiff_react_excercises/pull/1)
- Assuming we want to keep the 90% limit from the previous exercise, so that's always added as the last breakpoint. If we wanted to change this, we would only need to change that and only add it if we have empty breakpoints.